### PR TITLE
Fix address replacer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cadut",
-  "version": "0.1.9",
+  "version": "0.1.10-alpha.1",
   "description": "Flow Cadence Template Utilities",
   "author": "Maksim Daunarovich",
   "license": "Apache-2.0",

--- a/src/args.js
+++ b/src/args.js
@@ -81,7 +81,7 @@ export const reportArguments = (found, required, prefix = "") => {
  * @param {string} prefix - error message prefix
  */
 export const reportMissing = (itemType = "items", found, required, prefix = "") => {
-  if (required > found) {
+  if (required !== found) {
     const errorMessage = `Incorrect number of ${itemType}: found ${found} of ${required}`;
     const message = prefix ? `${prefix} ${errorMessage}` : errorMessage;
     console.error(message);

--- a/src/imports.js
+++ b/src/imports.js
@@ -101,6 +101,9 @@ export const replaceImportAddresses = (code, addressMap, byName = true) => {
   return code.replace(REGEXP_IMPORT, (match, imp, contract, _, address) => {
     const key = byName ? contract : address;
     const newAddress = addressMap instanceof Function ? addressMap(key) : addressMap[key];
-    return `${imp}${contract} from ${newAddress}`;
+
+    // If the address is not inside addressMap we shall not alter import statement
+    const validAddress = newAddress || address;
+    return `${imp}${contract} from ${validAddress}`;
   });
 };


### PR DESCRIPTION
Address replacer would use undefined if passed `addressMap` does not contain the contract address.
This PR fixes this behavior. 