### PR TITLE
Better error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-cadut",
-  "version": "0.1.14",
+  "version": "0.1.15-alpha.1",
   "description": "Flow Cadence Template Utilities",
   "author": "Maksim Daunarovich",
   "license": "Apache-2.0",

--- a/src/parser.js
+++ b/src/parser.js
@@ -65,16 +65,7 @@ export const extractTransactionArguments = (code) => {
 };
 
 export const extractContractName = (code) => {
-  const contractNameMatcher = /\w+\s+contract\s+(?:interface)*\s*(\w*)/g;
-  const noComments = stripComments(code);
-  const singleLine = noComments.replace(/\r\n|\n|\r/g, " ");
-  const matches = contractNameMatcher.exec(singleLine);
-
-  if (matches.length < 2) {
-    throw new Error("Contract Error: can't find name of the contract");
-  }
-
-  return matches[1];
+  return extractContractParameters(code).contractName
 };
 
 export const extractContractParameters = (code) => {
@@ -86,7 +77,7 @@ export const extractContractParameters = (code) => {
   const noComplex = noComments.replace(complexMatcher, "");
   const matches = contractNameMatcher.exec(noComplex);
 
-  if (matches.length < 2) {
+  if (!matches || matches.length < 2) {
     throw new Error("Contract Error: can't find name of the contract");
   }
 

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -174,7 +174,7 @@ describe("extract contract name", () => {
           post{}
       }
     `;
-    expect(()=> extractContractName(input)).toThrow("can't find name of the contract");
+    expect(()=> extractContractName(input)).toThrow("Contract Error: can't find name of the contract");
   });
 });
 

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -47,7 +47,6 @@ describe("strip comments", () => {
       pub fun /* hidden */main():String{ return "hello, world!" }
     `;
     const output = stripComments(input);
-    console.log(output);
     expect(output.includes("pub fun main")).toBe(true);
     expect(output.includes("hidden")).toBe(false);
   });

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -165,6 +165,17 @@ describe("extract contract name", () => {
     const output = extractContractName(input);
     expect(output).toEqual(contractName);
   });
+
+  test("extract contract name - transaction", () => {
+    const input = `
+      transaction {
+          pre {}
+          execute{}
+          post{}
+      }
+    `;
+    expect(()=> extractContractName(input)).toThrow("can't find name of the contract");
+  });
 });
 
 describe("extract contract parameters", () => {


### PR DESCRIPTION
Closes #38 

- Refactor code using existing method
- Throw `Contract Error: can't find name of the contract`, when incorrect template is passed