### PR TITLE
PKG -- [flow-cadut] Add valid domain checking to paths according to provided argument type

### DIFF
--- a/.changeset/rich-spies-draw.md
+++ b/.changeset/rich-spies-draw.md
@@ -1,0 +1,5 @@
+---
+"@onflow/flow-cadut": patch
+---
+
+Verify that provided domain is valid for provided argument type when mapping path arguments

--- a/packages/flow-cadut/src/args.js
+++ b/packages/flow-cadut/src/args.js
@@ -176,7 +176,7 @@ export const mapArgument = async (rawType, rawValue) => {
     }
 
     case isPath(type): {
-      return fcl.arg(parsePath(value), resolvedType)
+      return fcl.arg(parsePath(value, type), resolvedType)
     }
 
     case isArray(type): {

--- a/packages/flow-cadut/src/fixer.js
+++ b/packages/flow-cadut/src/fixer.js
@@ -32,16 +32,33 @@ export const padAddress = address => {
 
 export const toFixedValue = val => parseFloat(val).toFixed(8)
 
+export const toRequiredType = type => /^(.*)\??$/.exec(type)[1]
+
 export const domains = ["public", "private", "storage"]
 
-export const parsePath = path => {
+export const domainMap = {
+  PublicPath: ["public"],
+  PrivatePath: ["private"],
+  StoragePath: ["storage"],
+  CapabilityPath: ["public", "private"],
+  Path: ["public", "private", "storage"],
+}
+
+export const parsePath = (path, type = null) => {
   if (path.startsWith("/")) {
     const parts = path.slice(1).split("/")
     if (parts.length !== 2) {
       throw Error("Incorrect Path - identifier missing")
     }
     if (!domains.includes(parts[0])) {
-      throw Error("Incorrect Path - wrong domain")
+      throw Error(`Incorrect Path - ${parts[0]} is not a valid domain`)
+    }
+    if (type) {
+      if (!domainMap[toRequiredType(type)].includes(parts[0])) {
+        throw new Error(
+          `Incorrect Path - argument type "${type}" is not compatible with path domain "${parts[0]}"`
+        )
+      }
     }
     const [domain, identifier] = parts
     return {domain, identifier}

--- a/packages/flow-cadut/tests/fixer.test.js
+++ b/packages/flow-cadut/tests/fixer.test.js
@@ -48,10 +48,27 @@ describe("fixer", () => {
     }).toThrow("Incorrect Path - identifier missing")
   })
 
-  it("shall throw error on incorrect path - wrong domain", () => {
-    const input = `/planet/Mars`
+  it("shall throw error on incorrect path - ${domain} is not a valid domain", () => {
+    const domain = "planet"
+    const identifier = "Mars"
+
+    const input = `/${domain}/${identifier}`
     expect(() => {
       parsePath(input)
-    }).toThrow("Incorrect Path - wrong domain")
+    }).toThrow(`Incorrect Path - ${domain} is not a valid domain`)
+  })
+
+  it('shall throw error on incorrect path - argument type "${type}" is not compatible with path domain "${domain}"', () => {
+    const domain = "public"
+    const identifier = "foo"
+
+    const path = `/${domain}/${identifier}`
+    const type = "StoragePath"
+
+    expect(() => {
+      parsePath(path, type)
+    }).toThrow(
+      `Incorrect Path - argument type "${type}" is not compatible with path domain "${domain}"`
+    )
   })
 })


### PR DESCRIPTION
Closes #92 

## Description

Checks whether provided path domain is valid for provided argument type

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

