### PR TITLE
Updated simple-git dependency, addressing high sev vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20253,13 +20253,17 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.40.0.tgz",
-      "integrity": "sha512-7IO/eQwrN5kvS38TTu9ljhG9tx2nn0BTqZOmqpPpp51TvE44YIvLA6fETqEVA8w/SeEfPaVv6mk7Tsk9Jns+ag==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.12.0.tgz",
+      "integrity": "sha512-cy1RSRFHGZSrlYa3MnUuNVOXLUdifEZD2X8+AZjg8mKCdRvtCFSga6acq5N2g0ggb8lH3jBi369MrFZ+Y6sfsA==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.1"
+        "debug": "^4.3.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
     "node_modules/sisteransi": {
@@ -23552,7 +23556,7 @@
         "rimraf": "^3.0.2",
         "rlp": "^3.0.0",
         "sha3": "^2.1.4",
-        "simple-git": "^2.40.0",
+        "simple-git": "^3.12.0",
         "yargs": "^15.4.1"
       },
       "devDependencies": {
@@ -29588,7 +29592,7 @@
         "rimraf": "^3.0.2",
         "rlp": "^3.0.0",
         "sha3": "^2.1.4",
-        "simple-git": "^2.40.0",
+        "simple-git": "^3.12.0",
         "yargs": "^15.4.1"
       },
       "dependencies": {
@@ -42172,13 +42176,13 @@
       "dev": true
     },
     "simple-git": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.40.0.tgz",
-      "integrity": "sha512-7IO/eQwrN5kvS38TTu9ljhG9tx2nn0BTqZOmqpPpp51TvE44YIvLA6fETqEVA8w/SeEfPaVv6mk7Tsk9Jns+ag==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.12.0.tgz",
+      "integrity": "sha512-cy1RSRFHGZSrlYa3MnUuNVOXLUdifEZD2X8+AZjg8mKCdRvtCFSga6acq5N2g0ggb8lH3jBi369MrFZ+Y6sfsA==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.1"
+        "debug": "^4.3.4"
       }
     },
     "sisteransi": {

--- a/packages/flow-cadut/package.json
+++ b/packages/flow-cadut/package.json
@@ -38,7 +38,7 @@
     "rimraf": "^3.0.2",
     "rlp": "^3.0.0",
     "sha3": "^2.1.4",
-    "simple-git": "^2.40.0",
+    "simple-git": "^3.12.0",
     "yargs": "^15.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #124

## Description

Updated dependency version of simple-git from `^2.40.0` to `^3.12.0`

______

For contributor use:

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 

