### PR TITLE
Cadence 1.0 changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
 
         # install Flow CLI
       - name: Install Flow CLI
-        run: sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)"
+#        run: sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)"
+        run: sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/feature/stable-cadence/install.sh)"
 
         # use fresh install
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
 
       # install Flow CLI
       - name: Install Flow CLI
-        run: sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)"
+ #        run: sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)"
+        run: sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/feature/stable-cadence/install.sh)"
 
       - name: Install Dependencies
         run: npm i

--- a/packages/flow-cadut/src/interactions.js
+++ b/packages/flow-cadut/src/interactions.js
@@ -132,7 +132,7 @@ export const sendTransaction = async props => {
 // TODO: add arguments for "init" method into template
 export const addContractTemplate = `
     transaction(name: String, code: String) {
-      prepare(acct: AuthAccount){
+      prepare(acct: auth(AddContract) &Account) {
         let decoded = code.decodeHex()
         
         acct.contracts.add(
@@ -144,13 +144,13 @@ export const addContractTemplate = `
   `
 export const updateContractTemplate = `
   transaction(name: String, code: String){
-    prepare(acct: AuthAccount){
+    prepare(acct: auth(AddContract, UpdateContract) &Account) {
       let decoded = code.decodeHex()
       
       if acct.contracts.get(name: name) == nil {
         acct.contracts.add(name: name, code: decoded)
       } else {
-        acct.contracts.update__experimental(name: name, code: decoded)
+        acct.contracts.update(name: name, code: decoded)
       }
     }
   }

--- a/packages/flow-cadut/src/interactions.js
+++ b/packages/flow-cadut/src/interactions.js
@@ -155,6 +155,31 @@ export const updateContractTemplate = `
     }
   }
 `
+export const addContractTemplateLegacy = `
+    transaction(name: String, code: String) {
+      prepare(acct: AuthAccount) {
+        let decoded = code.decodeHex()
+        
+        acct.contracts.add(
+          name: name,
+          code: decoded,
+        )
+      }
+    }
+  `
+export const updateContractTemplateLegacy = `
+  transaction(name: String, code: String){
+    prepare(acct: AuthAccount) {
+      let decoded = code.decodeHex()
+      
+      if acct.contracts.get(name: name) == nil {
+        acct.contracts.add(name: name, code: decoded)
+      } else {
+        acct.contracts.update(name: name, code: decoded)
+      }
+    }
+  }
+`
 
 // TODO: add jsdoc
 export const hexContract = contract =>
@@ -169,16 +194,19 @@ export const deployContract = async props => {
     code: contractCode,
     update = false,
     processed = false,
+    legacy = false,
     addressMap = {},
   } = props
 
-  // Update imprort statement with addresses from addressMap
+  // Update import statement with addresses from addressMap
   const ixContractCode = processed
     ? contractCode
     : replaceImportAddresses(contractCode, addressMap)
 
   // TODO: Implement arguments for "init" method
-  const template = update ? addContractTemplate : updateContractTemplate
+  let template = update ? addContractTemplate : updateContractTemplate
+  if (legacy)
+    template = update ? addContractTemplateLegacy : updateContractTemplateLegacy
 
   const hexedCode = hexContract(ixContractCode)
   const args = [name, hexedCode]

--- a/packages/flow-cadut/src/parser.js
+++ b/packages/flow-cadut/src/parser.js
@@ -108,7 +108,7 @@ export const extractContractParameters = code => {
 export const getTemplateInfo = template => {
   const contractMatcher = /\w+\s+contract\s+(\w*\s*)\w*/g
   const transactionMatcher = /transaction\s*(\(\s*\))*\s*/g
-  const scriptMatcher = /pub\s+fun\s+main\s*/g
+  const scriptMatcher = /(pub|access\s*\(\s*all\s*\))\s+fun\s+main\s*/g
 
   const code = stripStrings(stripComments(template))
 

--- a/packages/flow-cadut/src/parser.js
+++ b/packages/flow-cadut/src/parser.js
@@ -23,11 +23,17 @@ export const TRANSACTION = "transaction"
 export const SCRIPT = "script"
 export const UNKNOWN = "unknown"
 
-export const generateSchema = argsDefinition =>
-  argsDefinition
-    .split(",")
-    .map(item => item.replace(/\s*/g, ""))
-    .filter(item => item !== "")
+export const generateSchema = argsDefinition => {
+  const matchedArgs = [
+    ...argsDefinition.matchAll(
+      /([^:]*:(\s*(auth)?\s*\([^)]*?\))?\s*[^,)]*),?/g
+    ),
+  ]
+  const splittedArgs = matchedArgs.map(
+    item => item[1]?.replace(/\s*/g, "") ?? ""
+  )
+  return splittedArgs.filter(item => item !== "")
+}
 
 export const stripComments = code => {
   const commentsRegExp = /(\/\*[\s\S]*?\*\/)|(\/\/.*)/g
@@ -71,7 +77,10 @@ export const extract = (code, keyWord) => {
 }
 
 export const extractSigners = code => {
-  return extract(code, `(?:prepare\\s*\\(\\s*)([^\\)]*)(?:\\))`)
+  return extract(
+    code,
+    `(?:prepare\\s*\\(\\s*)((?:[^:]*:(\\s*(auth)?\\s*\\([^)]*\\))?\\s*[^,)]*,?)*)(?:\\))`
+  )
 }
 
 export const extractScriptArguments = code => {

--- a/packages/flow-cadut/tests/args.test.js
+++ b/packages/flow-cadut/tests/args.test.js
@@ -343,6 +343,28 @@ describe("complex example", () => {
     expect(output[3].xform.label).toBe("UFix64")
   })
 
+  test("multiple values from code - cadence 1.0", async () => {
+    const code = `access(all) fun main(a: Int, b: Address, c: [String], d: UFix64) { }`
+    const argValues = [42, "0x01", ["Hello, World"], 1.337]
+
+    const schema = getTemplateInfo(code).args.map(argType)
+    const output = await mapArguments(schema, argValues)
+
+    expect(output.length).toBe(argValues.length)
+
+    expect(output[0].value).toBe(42)
+    expect(output[0].xform.label).toBe("Int")
+
+    expect(output[1].value).toBe("0x01")
+    expect(output[1].xform.label).toBe("Address")
+
+    expect(output[2].value).toEqual(["Hello, World"])
+    expect(output[2].xform.label).toBe("Array")
+
+    expect(output[3].value).toBe(toFixedValue("1.337"))
+    expect(output[3].xform.label).toBe("UFix64")
+  })
+
   test("multiple values from code - shall fail conversion", async () => {
     const code = `pub fun main(a: Int, b: Address, c: [String], d: UFix64) { }`
 

--- a/packages/flow-cadut/tests/parser.test.js
+++ b/packages/flow-cadut/tests/parser.test.js
@@ -107,6 +107,16 @@ describe("parser", () => {
     expect(output.length).toBe(0)
   })
 
+  test("extract script arguments - no arguments - cadence 1.0", () => {
+    const input = `
+      access(all) fun main(){
+        log(a)
+      }
+    `
+    const output = extractScriptArguments(input)
+    expect(output.length).toBe(0)
+  })
+
   test("extract script arguments", () => {
     const input = `
       pub fun main(a: Int){

--- a/packages/flow-cadut/tests/parser.test.js
+++ b/packages/flow-cadut/tests/parser.test.js
@@ -466,6 +466,21 @@ describe("template type checker", () => {
     const {type} = getTemplateInfo(input)
     expect(type).toBe(TRANSACTION)
   })
+
+  test("is transaction - Cadence 1.0", () => {
+    const input = `
+      import FlowManager from 0x01
+
+      transaction(name:String, code: String, manager: Address ##ARGS-WITH-TYPES##) {
+        prepare(acct: auth(BorrowValue ) & Account, other: auth (Entitlement, OtherEntitle) &Account){
+          let decoded = code.decodeHex()
+        }
+      }
+    `
+    const {type, signers} = getTemplateInfo(input)
+    expect(type).toBe(TRANSACTION)
+    expect(signers).toBe(2)
+  })
 })
 
 describe("spaces in definitions", () => {


### PR DESCRIPTION
## Description

quick bandage for cadence 1.0 enforcing scripts to begin with
`access(all) fun main`
instead of
`pub fun main`

which breaks cadut parser, which in turn is used by flow-js-testing

ideally should release a version with a fix for this ASAP, so that flow-js-testing can be fixed without patching


Also updated the templates for contract deploy/update.


---

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels

